### PR TITLE
Consider a client as disconnected on unexpected error.

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -510,7 +510,7 @@ uint8_t WiFiClient::connected()
                 break;
             default:
                 log_i("Unexpected: RES: %d, ERR: %d", res, errno);
-                _connected = true;
+                _connected = false;
                 break;
         }
     }


### PR DESCRIPTION
An unexpected error should be considered a disconnect.

Some code calls `client.connected()` and if false, `client.stop()`. Later, some other code calls `client.connected()` and it is true! It should be false after the client has been stopped.

Log shows:
```
14:29:00.846 -> [615859][I][WiFiClient.cpp:531] connected(): Unexpected: RES: -1, ERR: 9
14:44:00.216 -> [ 58760][E][WiFiClient.cpp:477] available(): fail on fd 0, errno: 9, "Bad file number"
```
Error 9 is "bad file number", because the client was stopped.

If we pretend the client is OK when we get an unexpected error code, we could easily never know that it's disconnected.